### PR TITLE
Installation without PIT

### DIFF
--- a/FCT/core/install.sql
+++ b/FCT/core/install.sql
@@ -9,12 +9,18 @@ define plsql_dir=&CORE_DIR.plsql/
 prompt - cleaning up installation
 @&CORE_DIR.clean_up.sql
 
-prompt - creating default messages
-@&CORE_DIR.create_default_messages.sql
+--prompt - creating default messages
+--@&CORE_DIR.create_default_messages.sql
 
 prompt - create type specifications
 prompt . - type &TOOLKIT._type
 @&type_dir.fsm_type.tps
+
+
+
+prompt - create char table
+prompt . - type char_table
+@&type_dir.char_table.tps
 
 prompt - create tables
 prompt . - table &TOOLKIT._CLASS

--- a/FCT/core/plsql/fsm_pkg.pkb
+++ b/FCT/core/plsql/fsm_pkg.pkb
@@ -1,33 +1,32 @@
-create or replace package body &TOOLKIT._pkg 
-as
-
+create or replace package body &TOOLKIT._pkg
+AS
   c_pkg constant varchar2(30 byte) := $$PLSQL_UNIT;
   c_cr constant char(1 byte) := chr(13);
-  
+
   g_log_level number;
   g_user varchar2(30 byte);
-  
+
   /* PL/SQL-Tabelle zur Speicherung der Status/Event-spezifischen Benachrichtigungsmails */
-  type &TOOLKIT._message_tab is table of varchar2(200 char)
-    index by &TOOLKIT._status.fst_id%type;
-  
+  type FCT_message_tab is table of varchar2(200 char)
+    index by FCT_status.fst_id%type;
+
   -- Instanzen
-  event_messages &TOOLKIT._message_tab;
-  event_names &TOOLKIT._message_tab;
-  status_messages &TOOLKIT._message_tab;
-  status_names &TOOLKIT._message_tab;
-  
+  event_messages FCT_message_tab;
+  event_names FCT_message_tab;
+  status_messages FCT_message_tab;
+  status_names FCT_message_tab;
+
   /* Initialisierungsprozedur des Packages */
   procedure initialize
   as
     cursor status_message_cur is
       select fst_id, fst_msg_id, fst_name
-        from &TOOLKIT._status;
+        from FCT_status;
     cursor event_message_cur is
       select fev_id, fev_msg_id, fev_name
-        from &TOOLKIT._event;
+        from FCT_event;
   begin
-    pit.enter_detailed('initialize', c_pkg);
+    --pit.enter_detailed('initialize', c_pkg);
     for fst in status_message_cur loop
       status_messages(fst.fst_id) := fst.fst_msg_id;
       status_names(fst.fst_id) := fst.fst_name;
@@ -36,34 +35,34 @@ as
       event_messages(fev.fev_id) := fev.fev_msg_id;
       event_names(fev.fev_id) := fev.fev_name;
     end loop;
-    g_log_level := param.get_integer('PIT_&TOOLKIT._DEFAULT_LOG_LEVEL', 'PIT');
+    --g_log_level := param.get_integer('PIT_FCT_DEFAULT_LOG_LEVEL', 'PIT');
     g_user := user;
-    pit.leave_detailed;
+    --pit.leave_detailed;
   end initialize;
-  
+
   /* HELPER */
-  /* Prozedur speichert einen erneuten Ausfuehrungsversuch einer &TOOLKIT. 
-   * %param p_&TOOLKIT. &TOOLKIT.-Instanz
+  /* Prozedur speichert einen erneuten Ausfuehrungsversuch einer FCT
+   * %param p_FCT FCT-Instanz
    * %param p_retry_schedule Schedule, der fuer den erneuten Versuch verwendet
    *        werden soll
-   * %usage Wird aufgerufen, wenn ein erneuter Ausfuehrungsversuch einer &TOOLKIT.-Instanz
+   * %usage Wird aufgerufen, wenn ein erneuter Ausfuehrungsversuch einer FCT-Instanz
    *        angeforert wird, um den Versuch zu persistieren
    */
   procedure persist_retry(
-    p_&TOOLKIT. in out nocopy &TOOLKIT._type,
-    p_retry_schedule in &TOOLKIT._object.&TOOLKIT._retry_schedule%type)
+    p_FCT in out nocopy FCT_type,
+    p_retry_schedule in FCT_object.FCT_retry_schedule%type)
   as
   begin
-    pit.enter_detailed('persist_retry', c_pkg);
-    update &TOOLKIT._object
-       set &TOOLKIT._validity = p_&TOOLKIT..&TOOLKIT._validity,
-           &TOOLKIT._retry_schedule = p_retry_schedule
-     where &TOOLKIT._id = p_&TOOLKIT..&TOOLKIT._id;
+    --pit.enter_detailed('persist_retry', c_pkg);
+    update FCT_object
+       set FCT_validity = p_FCT.FCT_validity,
+           FCT_retry_schedule = p_retry_schedule
+     where FCT_id = p_FCT.FCT_id;
     commit;
-    pit.leave_detailed;
+    --pit.leave_detailed;
   end persist_retry;
-  
-  
+
+
   /* Funktion liefert die aktuelle SESSION_ID, falls ueber APEX keine
    * APEX-Session vereinbart wurde
    */
@@ -72,358 +71,359 @@ as
   as
     l_session_id varchar2(30);
   begin
-    pit.enter_detailed('get_session_id', c_pkg);
+    --pit.enter_detailed('get_session_id', c_pkg);
     select to_char(sid || ',' || serial#)
       into l_session_id
       from v$session
      where rownum = 1;
-    pit.leave_detailed;
+    --pit.leave_detailed;
     return l_session_id;
   end get_session_id;
-  
-  
+
+
   /* Prozedur fordert einen erneuten Ausfuehrungsversuch an
-   * %param p_&TOOLKIT. &TOOLKIT.-Instanz
+   * %param p_FCT FCT-Instanz
    * %param p_fev_id Ereignis, das erneut ausgeloest werden soll
    * %param p_wait_time Wartezeit, nach der erneut ausgeloest werden soll
    * %param p_try_count Zaehler, der die Anzahl der Versuche aufzeichnet
    * %usage Wird aufgerufen, um ein Ereignis erneut auszuloesen.
    */
   procedure re_fire_event(
-    p_&TOOLKIT. in out nocopy &TOOLKIT._type,
-    p_fev_id in &TOOLKIT._event.fev_id%type,
-    p_wait_time in &TOOLKIT._status.fst_retry_time%type,
-    p_try_count in &TOOLKIT._status.fst_retries_on_error%type)
+    p_FCT in out nocopy FCT_type,
+    p_fev_id in FCT_event.fev_id%type,
+    p_wait_time in FCT_status.fst_retry_time%type,
+    p_try_count in FCT_status.fst_retries_on_error%type)
   as
     l_result number;
     l_try_count number;
   begin
-    pit.enter_optional('re_fire_event', c_pkg);
+    --pit.enter_optional('re_fire_event', c_pkg);
     if p_wait_time is not null then
-      pit.info(
-        msg.&TOOLKIT._RETRYING, 
+      /*pit.info(
+        msg.FCT_RETRYING,
         msg_args(
-          p_fev_id, 
-          p_&TOOLKIT..&TOOLKIT._fst_id, 
-          p_&TOOLKIT..&TOOLKIT._fev_list, 
-          to_char(p_try_count)), 
-          p_&TOOLKIT..&TOOLKIT._id);
+          p_fev_id,
+          p_FCT.FCT_fst_id,
+          p_FCT.FCT_fev_list,
+          to_char(p_try_count)),
+          p_FCT.FCT_id);*/
       -- Wait and retry status change
       dbms_lock.sleep(p_wait_time);
-      l_result := p_&TOOLKIT..raise_event(p_fev_id);
+      l_result := p_FCT.raise_event(p_fev_id);
     end if;
-    pit.leave_optional;
+    --pit.leave_optional;
   end re_fire_event;
-  
-  
+
+
   /* Prozedur stoppt die erneute Ausloesung eines Ereignisses und setzt die Instanz
    * in den Fehlestatus
-   * %param p_&TOOLKIT. &TOOLKIT.-Instanz
+   * %param p_FCT FCT-Instanz
    * %usage Sind keine erneuten Ausloesungen des Ereignisses erlaubt oder die maximale
    *        Wiederholungszahl erreicht, wird ein Fehlerereignis ausgeloest und die
    *        Verarbeitung gestoppt
    */
   procedure proceed_with_error_event(
-    p_&TOOLKIT. in out nocopy &TOOLKIT._type)
+    p_FCT in out nocopy FCT_type)
   as
     l_result number;
-    l_event &TOOLKIT._event.fev_id%type;
+    l_event FCT_event.fev_id%type;
   begin
-    pit.enter_optional('proceed_with_error_event', c_pkg);
-    pit.verbose(
-      msg.&TOOLKIT._VALIDITY, 
+    --pit.enter_optional('proceed_with_error_event', c_pkg);
+    /*pit.verbose(
+      msg.FCT_VALIDITY,
       msg_args(
-        to_char(p_&TOOLKIT..&TOOLKIT._validity)),
-        p_&TOOLKIT..&TOOLKIT._id);
+        to_char(p_FCT.FCT_validity)),
+        p_FCT.FCT_id);*/
     select ftr_fev_id
       into l_event
-      from &TOOLKIT._transition
-     where ftr_fst_id = p_&TOOLKIT..&TOOLKIT._fst_id
-       and ftr_fcl_id = p_&TOOLKIT..&TOOLKIT._fcl_id
+      from FCT_transition
+     where ftr_fst_id = p_FCT.FCT_fst_id
+       and ftr_fcl_id = p_FCT.FCT_fcl_id
        and ftr_raise_on_status = c_error;
-    pit.verbose(msg.&TOOLKIT._THROW_ERROR_EVENT, msg_args(l_event), p_&TOOLKIT..&TOOLKIT._id);
-    
-    p_&TOOLKIT..&TOOLKIT._fev_list := l_event;
-    p_&TOOLKIT..&TOOLKIT._validity := c_error;
-    
-    persist_retry(p_&TOOLKIT., null);
-    
-    l_result := p_&TOOLKIT..raise_event(l_event);
-    pit.leave_optional;
+--    pit.verbose(msg.FCT_THROW_ERROR_EVENT, msg_args(l_event), p_FCT.FCT_id);
+
+    p_FCT.FCT_fev_list := l_event;
+    p_FCT.FCT_validity := c_error;
+
+    persist_retry(p_FCT, null);
+
+    l_result := p_FCT.raise_event(l_event);
+    --pit.leave_optional;
   exception
     when no_data_found then
       -- Werfe generischen Fehler
-      l_result := p_&TOOLKIT..raise_event(&TOOLKIT._fev.&TOOLKIT._ERROR);
+      l_result := p_FCT.raise_event(FCT_fev.FCT_ERROR);
   end proceed_with_error_event;
-  
-  
-  /* Prozdur zur Pflege von &TOOLKIT._LOG
-   * %param p_&TOOLKIT. &TOOLKIT.-Instanz
+
+
+  /* Prozdur zur Pflege von FCT_LOG
+   * %param p_FCT FCT-Instanz
    * %param p_fev_id Ereignis, das ausgeloest wurde (optional)
    * %param p_fst_id Neuer Status, der eingenommen wurde (optional)
    * %param p_msg ID einer Nachricht aus PIT
    * %param p_msg_args MSG_ARGS-Instanz mit Nachrichtenparametern
    * %usage Wird aufgerufen, um Statuswechsel, Ereignisse und Notifications von
-   *        &TOOLKIT. zu protokollieren
+   *        FCT zu protokollieren
    */
   procedure log_change(
-    p_&TOOLKIT. in out nocopy &TOOLKIT._type,
-    p_fev_id in &TOOLKIT._event.fev_id%type default null,
-    p_fst_id in &TOOLKIT._status.fst_id%type default null,
-    p_msg in varchar2 default null,
-    p_msg_args in msg_args default null)
+    p_FCT in out nocopy FCT_type,
+    p_fev_id in FCT_event.fev_id%type default null,
+    p_fst_id in FCT_status.fst_id%type default null,
+    p_msg in varchar2 default null/*,
+    p_msg_args in msg_args default null*/)
   as
-    l_message message_type;
-    l_message_id message.message_name%type;
+  --  l_message message_type;
+   -- l_message_id message.message_name%type;
     l_user varchar2(50);
     l_session varchar2(50);
-    l_msg_args msg_args;    
-    c_pit_&TOOLKIT. constant varchar2(10) := 'PIT_&TOOLKIT.';
+    --l_msg_args msg_args;
+    c_pit_FCT constant varchar2(10) := 'PIT_FCT';
   begin
-    pit.enter_optional('log_change', c_pkg);
+    --pit.enter_optional('log_change', c_pkg);
     -- prepare Message
-    case
+    /*case
     when p_fev_id is not null then
-      l_message_id := event_messages(p_fev_id);
-      l_msg_args := msg_args(event_names(p_fev_id));
-    when p_fst_id = &TOOLKIT._fst.&TOOLKIT._ERROR then
-      l_message_id := msg.&TOOLKIT._DELIVERY_FAILED;
-      l_msg_args := msg_args(status_names(p_fst_id));
+      --l_message_id := event_messages(p_fev_id);
+      --l_msg_args := msg_args(event_names(p_fev_id));
+    when p_fst_id = FCT_fst.FCT_ERROR then
+      --l_message_id := msg.FCT_DELIVERY_FAILED;
+      --l_msg_args := msg_args(status_names(p_fst_id));
     when p_fst_id is not null then
-      l_message_id := status_messages(p_fst_id);
-      l_msg_args := msg_args(status_names(p_fst_id));
+      --l_message_id := status_messages(p_fst_id);
+      --l_msg_args := msg_args(status_names(p_fst_id));
     else
-      l_message_id := p_msg;
-      l_msg_args := p_msg_args;
+      --l_message_id := p_msg;
+      --l_msg_args := p_msg_args;
     end case;
-    
-    l_message := pit_pkg.get_message(l_message_id, to_char(p_&TOOLKIT..&TOOLKIT._id), l_msg_args);
+*/
+    --l_message := pit_pkg.get_message(l_message_id, to_char(p_FCT.FCT_id), l_msg_args);
     -- TODO: Pruefen, ob Ermittlung des Username/Session durch APEX_ADAPTER buggy ist
-    if instr(l_message.session_id, ':') > 0 then
-      l_user := substr(l_message.session_id, 1, instr(l_message.session_id, ':') - 1);
-      l_session := substr(l_message.session_id, instr(l_message.session_id, ':') + 1);
-    else
+  --  if instr(l_message.session_id, ':') > 0 then
+    --  l_user := substr(l_message.session_id, 1, instr(l_message.session_id, ':') - 1);
+    --  l_session := substr(l_message.session_id, instr(l_message.session_id, ':') + 1);
+   -- else
       l_user := g_user;
       l_session := get_session_id;
-    end if;
-    
+   -- end if;
+
     -- LOG
-    insert into &TOOLKIT._log(
-      fsl_id, fsl_&TOOLKIT._id, fsl_session_id, fsl_user_name, 
-      fsl_log_date, fsl_msg_text, fsl_severity, 
-      fsl_fst_id, fsl_fev_list, fsl_fcl_id, 
-      fsl_msg_id, fsl_msg_args)
+    insert into FCT_log(
+      fsl_id, /*fsl_FCT_id,*/ fsl_session_id, fsl_user_name,
+      fsl_log_date, --fsl_msg_text, fsl_severity,
+      fsl_fst_id, fsl_fev_list, fsl_fcl_id/*,
+      fsl_msg_id, fsl_msg_args*/)
     values(
-      &TOOLKIT._log_seq.nextval, to_number(l_message.affected_id), l_session, l_user,
-      current_timestamp, l_message.message_text, l_message.severity,
-      p_&TOOLKIT..&TOOLKIT._fst_id, p_&TOOLKIT..&TOOLKIT._fev_list, p_&TOOLKIT..&TOOLKIT._fcl_id,
-      l_message.message_name, pit_pkg.cast_to_char_list(l_message.message_args));
-    pit.leave_optional;
+      FCT_log_seq.nextval, /*to_number(l_message.affected_id),*/ l_session, l_user,
+      current_timestamp, --l_message.message_text, l_message.severity,
+      p_FCT.FCT_fst_id, p_FCT.FCT_fev_list, p_FCT.FCT_fcl_id/*,
+      l_message.message_name, pit_pkg.cast_to_char_list(l_message.message_args)*/
+      );
+    --pit.leave_optional;
   end log_change;
-  
-  
+
+
   /* INTERFACE */
   procedure persist(
-    p_&TOOLKIT. in &TOOLKIT._type)
+    p_FCT in FCT_type)
   as
   begin
-    pit.enter('persist', c_pkg, msg_params(msg_param('id', p_&TOOLKIT..&TOOLKIT._id)));
-    merge into &TOOLKIT._object o
-    using (select p_&TOOLKIT..&TOOLKIT._id &TOOLKIT._id,
-                  p_&TOOLKIT..&TOOLKIT._fcl_id &TOOLKIT._fcl_id,
-                  p_&TOOLKIT..&TOOLKIT._fst_id &TOOLKIT._fst_id,
-                  coalesce(p_&TOOLKIT..&TOOLKIT._validity, c_ok) &TOOLKIT._validity,
-                  p_&TOOLKIT..&TOOLKIT._fev_list &TOOLKIT._fev_list
+--    pit.enter('persist', c_pkg, msg_params(msg_param('id', p_FCT.FCT_id)));
+    merge into FCT_object o
+    using (select p_FCT.FCT_id FCT_id,
+                  p_FCT.FCT_fcl_id FCT_fcl_id,
+                  p_FCT.FCT_fst_id FCT_fst_id,
+                  coalesce(p_FCT.FCT_validity, c_ok) FCT_validity,
+                  p_FCT.FCT_fev_list FCT_fev_list
              from dual) v
-       on (o.&TOOLKIT._id = v.&TOOLKIT._id)
+       on (o.FCT_id = v.FCT_id)
      when matched then update set
-          &TOOLKIT._fst_id = v.&TOOLKIT._fst_id,
-          &TOOLKIT._validity = v.&TOOLKIT._validity,
-          &TOOLKIT._fev_list = v.&TOOLKIT._fev_list
-     when not matched then insert(&TOOLKIT._id, &TOOLKIT._fcl_id, &TOOLKIT._fst_id, &TOOLKIT._validity, &TOOLKIT._fev_list)
-          values(v.&TOOLKIT._id, v.&TOOLKIT._fcl_id, v.&TOOLKIT._fst_id, v.&TOOLKIT._validity, v.&TOOLKIT._fev_list);
-    pit.leave;
+          FCT_fst_id = v.FCT_fst_id,
+          FCT_validity = v.FCT_validity,
+          FCT_fev_list = v.FCT_fev_list
+     when not matched then insert(FCT_id, FCT_fcl_id, FCT_fst_id, FCT_validity, FCT_fev_list)
+          values(v.FCT_id, v.FCT_fcl_id, v.FCT_fst_id, v.FCT_validity, v.FCT_fev_list);
+    --pit.leave;
   end persist;
-  
+
 
   function raise_event(
-    p_&TOOLKIT. in out nocopy &TOOLKIT._type,
-    p_fev_id in &TOOLKIT._event.fev_id%type)
+    p_FCT in out nocopy FCT_type,
+    p_fev_id in FCT_event.fev_id%type)
     return integer
   as
-    l_message_id message.message_name%type;
-    l_old_fst_id &TOOLKIT._status.fst_id%type;
-    l_new_fst_id &TOOLKIT._status.fst_id%type;
+   -- l_message_id message.message_name%type;
+    l_old_fst_id FCT_status.fst_id%type;
+    l_new_fst_id FCT_status.fst_id%type;
   begin
-    pit.enter('raise_event', c_pkg);
+    --pit.enter('raise_event', c_pkg);
     -- LOG verwalten
     log_change(
-      p_&TOOLKIT. => p_&TOOLKIT., 
+      p_FCT => p_FCT,
       p_fev_id => p_fev_id);
-    p_&TOOLKIT..&TOOLKIT._validity := c_ok;
-    pit.leave;
+    p_FCT.FCT_validity := c_ok;
+    --pit.leave;
     return c_ok;
   exception
     when others then
-      pit.sql_exception(msg.&TOOLKIT._SQL_ERROR, msg_args(p_&TOOLKIT..&TOOLKIT._fcl_id, to_char(p_&TOOLKIT..&TOOLKIT._id), p_fev_id));
+      --pit.sql_exception(msg.FCT_SQL_ERROR, msg_args(p_FCT.FCT_fcl_id, to_char(p_FCT.FCT_id), p_fev_id));
       return c_error;
   end raise_event;
-    
-  
+
+
   procedure retry(
-    p_&TOOLKIT. in out nocopy &TOOLKIT._type,
-    p_fev_id in &TOOLKIT._event.fev_id%type)
+    p_FCT in out nocopy FCT_type,
+    p_fev_id in FCT_event.fev_id%type)
   as
-    cursor &TOOLKIT._cur (p_&TOOLKIT._id in &TOOLKIT._object.&TOOLKIT._id%type) is
-      select &TOOLKIT..&TOOLKIT._validity,
-             &TOOLKIT..&TOOLKIT._fev_id,
+    cursor FCT_cur (p_FCT_id in FCT_object.FCT_id%type) is
+      select FCT.FCT_validity,
+             FCT.FCT_fev_id,
              fst.fst_id,
-             fst.fst_retries_on_error, 
-             fst.fst_retry_schedule, 
+             fst.fst_retries_on_error,
+             fst.fst_retry_schedule,
              fst.fst_retry_time
-        from &TOOLKIT._object &TOOLKIT.
-        join &TOOLKIT._status fst
-          on &TOOLKIT..&TOOLKIT._fst_id = fst.fst_id
-         and &TOOLKIT..&TOOLKIT._fcl_id = fst.fst_fcl_id
-       where &TOOLKIT..&TOOLKIT._id = p_&TOOLKIT..&TOOLKIT._id
-         and &TOOLKIT..&TOOLKIT._validity != 1;
-    l_validity &TOOLKIT._object.&TOOLKIT._validity%type;
+        from FCT_object FCT
+        join FCT_status fst
+          on FCT.FCT_fst_id = fst.fst_id
+         and FCT.FCT_fcl_id = fst.fst_fcl_id
+       where FCT.FCT_id = p_FCT.FCT_id
+         and FCT.FCT_validity != 1;
+    l_validity FCT_object.FCT_validity%type;
   begin
-    pit.enter('retry', c_pkg);
-    for &TOOLKIT. in &TOOLKIT._cur(p_&TOOLKIT..&TOOLKIT._id) loop
-      if &TOOLKIT..fst_retries_on_error > 0 then
-        pit.verbose(msg.&TOOLKIT._RETRY_REQUESTED, msg_args(p_fev_id, &TOOLKIT..fst_id, c_true), p_&TOOLKIT..&TOOLKIT._id);
+    --pit.enter('retry', c_pkg);
+    for FCT in FCT_cur(p_FCT.FCT_id) loop
+      if FCT.fst_retries_on_error > 0 then
+        --pit.verbose(msg.FCT_RETRY_REQUESTED, msg_args(p_fev_id, FCT.fst_id, c_true), p_FCT.FCT_id);
         -- take retry into account
-        -- &TOOLKIT._VALIDITY may have one of the following values:
+        -- FCT_VALIDITY may have one of the following values:
         -- 0 = no retry planned yet (or succesful state conversion, then this method wouldn't have been called)
         -- 1 = Error, proceed with ftr_raise_on_status = 1 event
         -- > 1 = Retry already scheduled, register next try.
-        case &TOOLKIT..&TOOLKIT._validity 
+        case FCT.FCT_validity
         when 0 then
           -- retry not yet scheduled
-          p_&TOOLKIT..&TOOLKIT._validity := &TOOLKIT..fst_retries_on_error + 1;
-          persist_retry(p_&TOOLKIT., &TOOLKIT..fst_retry_schedule);
-          re_fire_event(p_&TOOLKIT., p_fev_id, &TOOLKIT..fst_retry_time, 1);
+          p_FCT.FCT_validity := FCT.fst_retries_on_error + 1;
+          persist_retry(p_FCT, FCT.fst_retry_schedule);
+          re_fire_event(p_FCT, p_fev_id, FCT.fst_retry_time, 1);
         when 1 then
           -- STUB, can not possibly happen
-          proceed_with_error_event(p_&TOOLKIT.);
+          proceed_with_error_event(p_FCT);
         when 2 then
-          proceed_with_error_event(p_&TOOLKIT.);
+          proceed_with_error_event(p_FCT);
         else
-          p_&TOOLKIT..&TOOLKIT._validity := &TOOLKIT..&TOOLKIT._validity - 1;
-          if p_&TOOLKIT..&TOOLKIT._validity > 2 then
-            p_&TOOLKIT..notify(msg.&TOOLKIT._RETRY_INFO);
+          p_FCT.FCT_validity := FCT.FCT_validity - 1;
+          /*if p_FCT.FCT_validity > 2 then
+            p_FCT.notify(msg.FCT_RETRY_INFO);
           else
-            p_&TOOLKIT..notify(msg.&TOOLKIT._RETRY_WARN);
-          end if;
-          persist_retry(p_&TOOLKIT., &TOOLKIT..fst_retry_schedule);
-          l_validity := &TOOLKIT..fst_retries_on_error - &TOOLKIT..&TOOLKIT._validity + 1;
-          re_fire_event(p_&TOOLKIT., p_fev_id, &TOOLKIT..fst_retry_time, l_validity);
+            p_FCT.notify(msg.FCT_RETRY_WARN);
+          end if;*/
+          persist_retry(p_FCT, FCT.fst_retry_schedule);
+          l_validity := FCT.fst_retries_on_error - FCT.FCT_validity + 1;
+          re_fire_event(p_FCT, p_fev_id, FCT.fst_retry_time, l_validity);
         end case;
       else
-        pit.verbose(msg.&TOOLKIT._RETRY_REQUESTED, msg_args(p_fev_id, &TOOLKIT..fst_id, c_false), p_&TOOLKIT..&TOOLKIT._id);
-        proceed_with_error_event(p_&TOOLKIT.);
+        --pit.verbose(msg.FCT_RETRY_REQUESTED, msg_args(p_fev_id, FCT.fst_id, c_false), p_FCT.FCT_id);
+        proceed_with_error_event(p_FCT);
       end if;
-      pit.leave;
+      --pit.leave;
     end loop;
   end retry;
-  
-  
+
+
   function allows_event(
-    p_&TOOLKIT. in out nocopy &TOOLKIT._type,
-    p_fev_id &TOOLKIT._event.fev_id%type)
+    p_FCT in out nocopy FCT_type,
+    p_fev_id FCT_event.fev_id%type)
     return boolean
   as
     l_result boolean;
     l_has_role number;
   begin
-    pit.enter_optional('&TOOLKIT._allows_event', c_pkg);
+    --pit.enter_optional('FCT_allows_event', c_pkg);
     -- Pruefe, ob Event im aktuellen Status erlaubt ist
-    l_result := instr(':' || p_&TOOLKIT..&TOOLKIT._fev_list || ':', ':' || p_fev_id || ':') > 0;
-    
+    l_result := instr(':' || p_FCT.FCT_fev_list || ':', ':' || p_fev_id || ':') > 0;
+
     -- Pruefe, ob aktueller Benutzer erforderliche Rollenrechte besitzt
-    select case 
+    select case
            when ftr_required_role is not null then 0 --auth_user.is_authorized(ftr_required_role)
            else 1 end
       into l_has_role
-      from &TOOLKIT._transition
+      from FCT_transition
      where ftr_fev_id = p_fev_id
-       and ftr_fst_id = p_&TOOLKIT..&TOOLKIT._fst_id
-       and ftr_fcl_id = p_&TOOLKIT..&TOOLKIT._fcl_id;
-    
-    pit.leave_optional;
+       and ftr_fst_id = p_FCT.FCT_fst_id
+       and ftr_fcl_id = p_FCT.FCT_fcl_id;
+
+    --pit.leave_optional;
     return l_result and l_has_role > 0;
   exception
     when no_data_found then
       return false;
   end allows_event;
-  
-  
+
+
   function set_status(
-    p_&TOOLKIT. in out nocopy &TOOLKIT._type)
+    p_FCT in out nocopy FCT_type)
     return number
   as
-    cursor next_event_cur(p_&TOOLKIT. in &TOOLKIT._type) is
+    cursor next_event_cur(p_FCT in FCT_type) is
       select listagg(fev_id, ':') within group (order by fev_id) fev_list,
              max(ftr_raise_automatically) event_auto
-        from bl_&TOOLKIT._active_status_event
-       where fst_id = p_&TOOLKIT..&TOOLKIT._fst_id
-         and fcl_id = p_&TOOLKIT..&TOOLKIT._fcl_id
-         and ftr_raise_on_status = p_&TOOLKIT..&TOOLKIT._validity;
-    l_old_fst_id &TOOLKIT._status.fst_id%type;
+        from bl_FCT_active_status_event
+       where fst_id = p_FCT.FCT_fst_id
+         and fcl_id = p_FCT.FCT_fcl_id
+         and ftr_raise_on_status = p_FCT.FCT_validity;
+    l_old_fst_id FCT_status.fst_id%type;
     l_result number := c_ok;
   begin
-    pit.enter('set_status', c_pkg);
-    pit.assert_not_null(p_&TOOLKIT..&TOOLKIT._fst_id);
-    p_&TOOLKIT..&TOOLKIT._validity := coalesce(p_&TOOLKIT..&TOOLKIT._validity, c_ok);
-    
-    -- Ermittle nächste mögliche Events
-    for evt in next_event_cur(p_&TOOLKIT.) loop
-      p_&TOOLKIT..&TOOLKIT._fev_list := evt.fev_list;
-      p_&TOOLKIT..&TOOLKIT._auto_raise := evt.event_auto;
+    --pit.enter('set_status', c_pkg);
+    --pit.assert_not_null(p_FCT.FCT_fst_id);
+    p_FCT.FCT_validity := coalesce(p_FCT.FCT_validity, c_ok);
+
+    -- Ermittle nÃ¤chste mÃ¶gliche Events
+    for evt in next_event_cur(p_FCT) loop
+      p_FCT.FCT_fev_list := evt.fev_list;
+      p_FCT.FCT_auto_raise := evt.event_auto;
     end loop;
-    
-    persist(p_&TOOLKIT.);
-    
+
+    persist(p_FCT);
+
     log_change(
-      p_&TOOLKIT. => p_&TOOLKIT.,
-      p_fst_id => p_&TOOLKIT..&TOOLKIT._fst_id);
-    
-    notify(p_&TOOLKIT., msg.&TOOLKIT._NEXT_EVENTS, msg_args(p_&TOOLKIT..&TOOLKIT._fev_list, p_&TOOLKIT..&TOOLKIT._auto_raise));
-    
-    pit.leave;
-    return p_&TOOLKIT..&TOOLKIT._validity;
+      p_FCT => p_FCT,
+      p_fst_id => p_FCT.FCT_fst_id);
+
+    --notify(p_FCT, msg.FCT_NEXT_EVENTS, msg_args(p_FCT.FCT_fev_list, p_FCT.FCT_auto_raise));
+
+    --pit.leave;
+    return p_FCT.FCT_validity;
   exception
-    when msg.ASSERTION_FAILED_ERR then
-      if p_&TOOLKIT..&TOOLKIT._fst_id != &TOOLKIT._fst.&TOOLKIT._ERROR then
-        p_&TOOLKIT..&TOOLKIT._fst_id := &TOOLKIT._fst.&TOOLKIT._ERROR;
-        return set_status(p_&TOOLKIT.);
+    /*when msg.ASSERTION_FAILED_ERR then
+      if p_FCT.FCT_fst_id != FCT_fst.FCT_ERROR then
+        p_FCT.FCT_fst_id := FCT_fst.FCT_ERROR;
+        return set_status(p_FCT);
       else
         return c_error;
-      end if;
+      end if;*/
     when others then
-      pit.sql_exception(msg.SQL_ERROR);
-      if p_&TOOLKIT..&TOOLKIT._fst_id != &TOOLKIT._fst.&TOOLKIT._ERROR then
-        p_&TOOLKIT..&TOOLKIT._fst_id := &TOOLKIT._fst.&TOOLKIT._ERROR;
-        return set_status(p_&TOOLKIT.);
+--      pit.sql_exception(msg.SQL_ERROR);
+      if p_FCT.FCT_fst_id != FCT_fst.FCT_ERROR then
+        p_FCT.FCT_fst_id := FCT_fst.FCT_ERROR;
+        return set_status(p_FCT);
       else
         return c_error;
       end if;
   end set_status;
-  
-  
+
+
   procedure set_status(
-    p_&TOOLKIT. in out nocopy &TOOLKIT._type)
+    p_FCT in out nocopy FCT_type)
   as
     l_result number;
   begin
-    l_result := set_status(p_&TOOLKIT.);
+    l_result := set_status(p_FCT);
   end set_status;
-  
-  
+
+
   function get_next_status(
-    p_&TOOLKIT. in out nocopy &TOOLKIT._type,
-    p_fev_id in &TOOLKIT._event.fev_id%type)
+    p_FCT in out nocopy FCT_type,
+    p_fev_id in FCT_event.fev_id%type)
     return varchar2
   as
     l_next_fst_id varchar2(4000);
@@ -431,64 +431,65 @@ as
   begin
     select listagg(ftr_fst_list, c_delimiter) within group (order by ftr_fst_list)
       into l_next_fst_id
-      from &TOOLKIT._transition
-     where ftr_fst_id = p_&TOOLKIT..&TOOLKIT._fst_id
+      from FCT_transition
+     where ftr_fst_id = p_FCT.FCT_fst_id
        and ftr_fev_id = p_fev_id
-       and ftr_fcl_id = p_&TOOLKIT..&TOOLKIT._fcl_id;
+       and ftr_fcl_id = p_FCT.FCT_fcl_id;
     if instr(l_next_fst_id, c_delimiter) = 0 then
-      notify(p_&TOOLKIT., msg.&TOOLKIT._NEXT_STATUS_RECOGNIZED, msg_args(l_next_fst_id));
+--      notify(p_FCT, msg.FCT_NEXT_STATUS_RECOGNIZED, msg_args(l_next_fst_id));
       return l_next_fst_id;
     else
-      pit.error(msg.&TOOLKIT._NEXT_STATUS_NU, msg_args(p_&TOOLKIT..&TOOLKIT._fst_id), p_&TOOLKIT..&TOOLKIT._id);
+--      pit.error(msg.FCT_NEXT_STATUS_NU, msg_args(p_FCT.FCT_fst_id), p_FCT.FCT_id);
       return null;
     end if;
   exception
     when no_data_found then
-      pit.error(msg.&TOOLKIT._NEXT_STATUS_NU, msg_args(p_&TOOLKIT..&TOOLKIT._fst_id), p_&TOOLKIT..&TOOLKIT._id);
+--      pit.error(msg.FCT_NEXT_STATUS_NU, msg_args(p_FCT.FCT_fst_id), p_FCT.FCT_id);
       return null;
-  end get_next_status;    
-  
-  
+  end get_next_status;
+
+
   procedure notify(
-    p_&TOOLKIT. in out nocopy &TOOLKIT._type,
-    p_msg in varchar2,
-    p_msg_args in msg_args)
+    p_FCT in out nocopy FCT_type,
+    p_msg in varchar2/*,
+    p_msg_args in msg_args*/)
   as
   begin
-    pit.enter('notify', c_pkg);
+    --pit.enter('notify', c_pkg);
     log_change(
-      p_&TOOLKIT. => p_&TOOLKIT.,
-      p_msg => p_msg,
-      p_msg_args => p_msg_args);
-    pit.leave;
+      p_FCT => p_FCT,
+      p_msg => p_msg/*,
+      p_msg_args => p_msg_args*/
+      );
+    --pit.leave;
   end notify;
-  
-  
+
+
   function to_string(
-    p_&TOOLKIT. in &TOOLKIT._type)
+    p_FCT in FCT_type)
     return varchar2
   as
-    l_result varchar2(32767) := 
-    q'[Instanz vom Typ &TOOLKIT._TYPE
-    &TOOLKIT._ID: #&TOOLKIT._ID#
-    &TOOLKIT._fcl_id: #&TOOLKIT._FCL_ID#
-    &TOOLKIT._fst_id: #&TOOLKIT._FST_ID#
-    &TOOLKIT._VALIDITY: #&TOOLKIT._VALIDITY#
+    l_result varchar2(32767) :=
+    q'[Instanz vom Typ FCT_TYPE
+    FCT_ID: #FCT_ID#
+    FCT_fcl_id: #FCT_FCL_ID#
+    FCT_fst_id: #FCT_FST_ID#
+    FCT_VALIDITY: #FCT_VALIDITY#
     event_list: #FEV_LIST#
 ]';
   begin
-    &TOOLKIT._util.bulk_replace(l_result, char_table(
-      '#&TOOLKIT._ID#', p_&TOOLKIT..&TOOLKIT._id,
-      '#&TOOLKIT._FCL_ID#', p_&TOOLKIT..&TOOLKIT._fcl_id,
-      '#&TOOLKIT._FST_ID#', p_&TOOLKIT..&TOOLKIT._fst_id,
-      '#&TOOLKIT._VALIDITY#', p_&TOOLKIT..&TOOLKIT._validity,
-      '#FEV_LIST#', p_&TOOLKIT..&TOOLKIT._fev_list));
+    FCT_util.bulk_replace(l_result, char_table(
+      '#FCT_ID#', p_FCT.FCT_id,
+      '#FCT_FCL_ID#', p_FCT.FCT_fcl_id,
+      '#FCT_FST_ID#', p_FCT.FCT_fst_id,
+      '#FCT_VALIDITY#', p_FCT.FCT_validity,
+      '#FEV_LIST#', p_FCT.FCT_fev_list));
     return l_result;
   end to_string;
-  
-  
+
+
   procedure finalize(
-    p_&TOOLKIT. &TOOLKIT._type)
+    p_FCT FCT_type)
   as
   begin
     null;

--- a/FCT/core/plsql/fsm_pkg.pks
+++ b/FCT/core/plsql/fsm_pkg.pks
@@ -1,10 +1,10 @@
 create or replace package &TOOLKIT._pkg
-  authid current_user -- FÃ¼r Leserecht auf USER_IDENTIFIERS
+  authid current_user -- Für Leserecht auf USER_IDENTIFIERS
 as
   /* Package zur generischen Verwaltung einer Finite State Machine (&TOOLKIT.)
    * %usage: Das Package beinhaltet die Implementierung der abstrakten Klasse
    *         &TOOLKIT._TYPE und stellt generische Funktionen zum Logging, zur Verwaltung
-   *         von Events und StatusÃ¤nderungen bereit.
+   *         von Events und Statusänderungen bereit.
    */
 
   /* Packagekonstanten zur Verwendung in abgeleiteten &TOOLKIT.-Instanzen */
@@ -27,8 +27,8 @@ as
     return integer;
 
 
-  /* "Konstruktor"-Prozedur: Erstellt kein Objekt, sondern lediglich EintrÃ¤ge
-   * in &TOOLKIT._OBJECT als Referenzpunkt fÃ¼r Konstruktormethoden der abgeleiteten Klassen.
+  /* "Konstruktor"-Prozedur: Erstellt kein Objekt, sondern lediglich Einträge
+   * in &TOOLKIT._OBJECT als Referenzpunkt für Konstruktormethoden der abgeleiteten Klassen.
    * %param p_&TOOLKIT. &TOOLKIT._TYPE-Instanz
    * %usage Wird von den Konstruktoren der abgeleiteten Klassen aufgerufen, um
    *        einen Eintrag in &TOOLKIT._OBJECT zu erstellen. Falls vorhanden, werden Attribute
@@ -64,16 +64,16 @@ as
     return boolean;
 
 
-  /* Funktion zum Ã„ndern eines Status.
+  /* Funktion zum Ändern eines Status.
    * %param p_&TOOLKIT. Instanz der &TOOLKIT. (konkrete Klasse des von &TOOLKIT._TYPE geerbeten Typs)
-   * %return Erfolgflag. Normalerweise 0 = Fehler oder 1 = OK. Es kÃ¶nnen aber auch
+   * %return Erfolgflag. Normalerweise 0 = Fehler oder 1 = OK. Es können aber auch
    *         weitere Returnwerte verarbeitet werden. Die Werte werden in &TOOLKIT._VALIDITY
    *         des &TOOLKIT.-Objekts gespeichert.
    * %usage Ein neuer Status wird durch die Logik des Eventhandlers bestimmt und
-   *        in die Klasse eingetragen. Auf Basis des neuen Status kÃ¶nnen weitere
-   *        Events ermittelt werden, die nun ausgelÃ¶st werden kÃ¶nnen.
-   *        Ist der nachfolgende Event automatisch, wird er unmittelbar ausgelÃ¶st,
-   *        ansonsten wartet die &TOOLKIT. auf die AuslÃ¶sung des entsprechenden Status.
+   *        in die Klasse eingetragen. Auf Basis des neuen Status können weitere
+   *        Events ermittelt werden, die nun ausgelöst werden können.
+   *        Ist der nachfolgende Event automatisch, wird er unmittelbar ausgelöst,
+   *        ansonsten wartet die &TOOLKIT. auf die Auslösung des entsprechenden Status.
    */
   function set_status(
     p_&TOOLKIT. in out nocopy &TOOLKIT._type)
@@ -104,14 +104,14 @@ as
   /* Prozedur speichert eine Notiz zu einer &TOOLKIT.-Instanz
    * %param p_&TOOLKIT. Instanz von &TOOLKIT._TYPE, zu der eine Notiz gespeichert werden soll
    * %param p_note_type Referenz auf MSG, wird als Meldung erstellt
-   * %param p_comment zusÃ¤tzlicher Kommentar, Freitext, wird als MSG_ARG interpretiert
-   * %usage Die Prozedur wird wÃ¤hrend der Bearbeitung aufgerufen, um Vermerke
+   * %param p_comment zusätzlicher Kommentar, Freitext, wird als MSG_ARG interpretiert
+   * %usage Die Prozedur wird während der Bearbeitung aufgerufen, um Vermerke
    *        zur Bearbeitung zu speichern
    */
   procedure notify(
     p_&TOOLKIT. in out nocopy &TOOLKIT._type,
-    p_msg in varchar2,
-    p_msg_args in msg_args);
+    p_msg in varchar2/*,
+    p_msg_args in msg_args*/);
 
 
   /* Funktion zur Umwandlung des Objects in eine Zeichenkette

--- a/FCT/core/plsql/fsm_util.pkb
+++ b/FCT/core/plsql/fsm_util.pkb
@@ -1,4 +1,4 @@
-create or replace package body FCT_util
+create or replace package body &TOOLKIT._util
 as
 
   /* INTERFACE */
@@ -13,7 +13,7 @@ as
     p_replacement char_table)
   as
   begin
-	pit.enter_detailed;
+	--pit.enter_detailed;
     for l_replacement_count in 1 .. p_replacement.count
     loop
       if (l_replacement_count mod 2 = 1) then
@@ -23,7 +23,7 @@ as
                      p_replacement(l_replacement_count + 1));
       end if;
     end loop;
-	pit.leave_detailed;
+	--pit.leave_detailed;
   end bulk_replace;
 
 
@@ -34,10 +34,10 @@ as
   as
     l_val varchar2(32767);
   begin
-	pit.enter_detailed;
+	--pit.enter_detailed;
     l_val := p_value;
     bulk_replace(l_val, p_replacement);
-	pit.leave_detailed;
+	--pit.leave_detailed;
     return l_val;
   end bulk_replace;
 

--- a/FCT/core/sql/tables/fsm_event.tbl
+++ b/FCT/core/sql/tables/fsm_event.tbl
@@ -13,8 +13,8 @@ create table &TOOLKIT._event (
   constraint pk_&TOOLKIT._event primary key (fev_id, fev_fcl_id) enable,
   constraint fk_fev_fcl_id foreign key (fev_fcl_id)
 	  references &TOOLKIT._class (fcl_id),
-  constraint fk_fev_msg_id foreign key (fev_msg_id)
-	  references message (message_id),
+  /*constraint fk_fev_msg_id foreign key (fev_msg_id)
+	  references message (message_id),*/
   constraint nn_fev_command check (fev_command is not null),
   constraint nn_fev_name check (fev_name is not null),
   constraint nn_fev_msg_id check (fev_msg_id is not null)

--- a/FCT/core/sql/tables/fsm_log.tbl
+++ b/FCT/core/sql/tables/fsm_log.tbl
@@ -10,7 +10,7 @@ create table &TOOLKIT._log(
 	fsl_fev_list varchar2(200 char), 
 	fsl_fcl_id varchar2(30 char), 
 	fsl_msg_id varchar2(30 char), 
-	fsl_msg_args msg_args_char,
+	--fsl_msg_args msg_args_char,
   constraint pk_&TOOLKIT._log primary key (fsl_id),
   constraint fsl_&TOOLKIT._id foreign key (fsl_&TOOLKIT._id)
 	  references &TOOLKIT._object (&TOOLKIT._id) on delete cascade

--- a/FCT/core/sql/tables/fsm_status.tbl
+++ b/FCT/core/sql/tables/fsm_status.tbl
@@ -14,8 +14,8 @@ create table &TOOLKIT._status(
 	  references &TOOLKIT._class (fcl_id),
   constraint fk_fst_fsg_id foreign key (fst_fsg_id)
 	  references &TOOLKIT._status_group (fsg_id),
-  constraint fk_fst_msg_id foreign key (fst_msg_id)
-	  references message (message_id),
+  /*constraint fk_fst_msg_id foreign key (fst_msg_id)
+	  references message (message_id),*/
   constraint nn_fst_active check (fst_active is not null),
   constraint nn_fst_msg_id check (fst_msg_id is not null),
   constraint chk_fst_active check (fst_active in ('Y', 'N')),

--- a/FCT/core/sql/types/char_table.tps
+++ b/FCT/core/sql/types/char_table.tps
@@ -1,0 +1,2 @@
+create or replace type char_table as table of varchar2(4000);
+/

--- a/FCT/core/sql/types/fsm_type.tpb
+++ b/FCT/core/sql/types/fsm_type.tpb
@@ -51,14 +51,14 @@ create or replace type body &TOOLKIT._type as
 
 
   member procedure notify(
-    p_msg in varchar2,
-    p_msg_args in msg_args default null)
+    p_msg in varchar2/*,
+    p_msg_args in msg_args default null*/)
   as
   begin
     &TOOLKIT._pkg.notify(
       p_&TOOLKIT. => self,
-      p_msg => p_msg,
-      p_msg_args => p_msg_args);
+      p_msg => p_msg/*,
+      p_msg_args => p_msg_args*/);
   end notify;
 
   member function to_string

--- a/FCT/core/sql/types/fsm_type.tps
+++ b/FCT/core/sql/types/fsm_type.tps
@@ -22,8 +22,8 @@ as object(
     p_fst_id in varchar2)
     return number,
   member procedure notify(
-    p_msg in varchar2,
-    p_msg_args in msg_args default null),
+    p_msg in varchar2/*,
+    p_msg_args in msg_args default null*/),
   member function to_string
     return varchar2,
   member procedure finalize

--- a/FCT/install.bat
+++ b/FCT/install.bat
@@ -1,5 +1,5 @@
 @echo off
-set nls_lang=GERMAN_GERMANY.AL32UTF8
+rem set nls_lang=GERMAN_GERMANY.AL32UTF8
 set /p Credentials= Enter a connect string without 'as sysdba' for SYS:
 set /p InstallUser= Enter username where the software shall be installed at:
 set /p Tablespace= Enter tablespace for user %InstallUser%:

--- a/FCT/sample/clean_up_install.sql
+++ b/FCT/sample/clean_up_install.sql
@@ -39,8 +39,9 @@ begin
     end;
   end loop;
   
-  delete from message
-   where message_name in ('');
+ /* delete from message
+   where message_name in ('');*/
+   
    
   delete from parameter_tab
    where parameter_group_id = '&TOOLKIT.'

--- a/FCT/sample/install.sql
+++ b/FCT/sample/install.sql
@@ -5,10 +5,10 @@ define FSM_CLASS=REQ
 
 prompt &h2.Installing sample application
 prompt &h3.Remove existing installation
-@&sample_dir.clean_up_install.sql
+--@&sample_dir.clean_up_install.sql
 
 prompt &s1.Create internal messages
-@&sample_dir./create_default_messages.sql
+--@&sample_dir./create_default_messages.sql
 
 prompt &h3.Create initial status, events and transitions
 @&sample_dir.create_initial_data.sql

--- a/FCT/sample/plsql/fsm_req_pkg.pkb
+++ b/FCT/sample/plsql/fsm_req_pkg.pkb
@@ -16,7 +16,7 @@ as
     p_req in &TOOLKIT._req_type)
   as
   begin
-    pit.enter('persist', c_pkg);
+    --pit.enter('persist', c_pkg);
 
     -- propagation to abstract super class
     &TOOLKIT._pkg.persist(p_req);
@@ -36,7 +36,7 @@ as
 
     commit;
 
-    pit.leave;
+    --pit.leave;
   end persist;
   
   
@@ -46,11 +46,11 @@ as
     return number
   as
   begin
-    pit.enter('raise_initialize', c_pkg);
+    --pit.enter('raise_initialize', c_pkg);
     g_result := c_ok;
     -- Logic goes here
     p_req.&TOOLKIT._validity := g_result;
-    pit.leave;
+    --pit.leave;
     return p_req.set_status(&TOOLKIT._fst.REQ_IN_PROCESS);
   end raise_initialize;
   
@@ -63,7 +63,7 @@ as
     c_object_priv constant &TOOLKIT._req_types.rtp_id%type := 'OBJECT_PRIV';
     c_system_priv constant &TOOLKIT._req_types.rtp_id%type := 'SYSTEM_PRIV';
   begin
-    pit.enter('raise_check', c_pkg);
+    --pit.enter('raise_check', c_pkg);
     g_result := c_ok;
     -- Logic goes here
     case 
@@ -76,7 +76,7 @@ as
     end case;
     
     p_req.&TOOLKIT._validity := g_result;
-    pit.leave;
+    --pit.leave;
     return p_req.set_status(l_new_status);
   end raise_check;
   
@@ -86,11 +86,11 @@ as
     return number
   as
   begin
-    pit.enter('raise_grant', c_pkg);
+    --pit.enter('raise_grant', c_pkg);
     g_result := c_ok;
     -- Logic goes here
     p_req.&TOOLKIT._validity := g_result;
-    pit.leave;
+    --pit.leave;
     return p_req.set_status(&TOOLKIT._fst.REQ_GRANTED);
   end raise_grant;
   
@@ -100,11 +100,11 @@ as
     return number
   as
   begin
-    pit.enter('raise_reject', c_pkg);
+    --pit.enter('raise_reject', c_pkg);
     g_result := c_ok;
     -- Logic goes here
     p_req.&TOOLKIT._validity := g_result;
-    pit.leave;
+    --pit.leave;
     return p_req.set_status(&TOOLKIT._fst.REQ_REJECTED);
   end raise_reject;
 
@@ -114,9 +114,9 @@ as
     return number
   as
   begin
-    pit.enter('raise_nil', c_pkg);
+    --pit.enter('raise_nil', c_pkg);
     -- no implementation required, event shouldn't be fired ever
-    pit.leave;
+    --pit.leave;
     p_req.&TOOLKIT._validity := c_ok;
     return p_req.set_status(&TOOLKIT._fst.&TOOLKIT._ERROR);
   end raise_nil;
@@ -134,7 +134,7 @@ as
   as 
     l_req_id &TOOLKIT._req_object.req_id%type;
   begin
-    pit.enter('create_&TOOLKIT._req', c_pkg);
+    --pit.enter('create_&TOOLKIT._req', c_pkg);
     l_req_id := coalesce(p_req_id, &TOOLKIT._seq.nextval);
 
     p_req.&TOOLKIT._id := l_req_id;
@@ -146,13 +146,13 @@ as
     p_req.req_text := p_req_text;
 
     if p_req_id is null then
-      pit.verbose(msg.&TOOLKIT._CREATED, msg_args(c_fcl_id, to_char(l_req_id)), l_req_id);
+      --pit.verbose(msg.&TOOLKIT._CREATED, msg_args(c_fcl_id, to_char(l_req_id)), l_req_id);
       g_result := p_req.set_status(&TOOLKIT._fst.REQ_CREATED);
     else
       persist(p_req);
     end if;
     
-    pit.leave;
+    --pit.leave;
   end create_&TOOLKIT._req;
     
 
@@ -183,7 +183,7 @@ as
     return integer
   as
   begin
-    pit.enter('raise_event', c_pkg);
+    --pit.enter('raise_event', c_pkg);
     -- propagate event to super class
     g_result := &TOOLKIT._pkg.raise_event(p_req, p_fev_id);
 
@@ -201,14 +201,15 @@ as
         g_result := raise_reject(p_req);
       when &TOOLKIT._fev.&TOOLKIT._NIL then
         g_result := raise_nil(p_req);
-      else
-        pit.warn(msg.&TOOLKIT._INVALID_EVENT, msg_args(p_fev_id), p_req.&TOOLKIT._id);
+      ELSE
+          NULL;
+        --pit.warn(msg.&TOOLKIT._INVALID_EVENT, msg_args(p_fev_id), p_req.&TOOLKIT._id);
       end case;
     else
-      pit.warn(msg.&TOOLKIT._EVENT_NOT_ALLOWED, msg_args(p_fev_id, p_req.&TOOLKIT._fst_id), p_req.&TOOLKIT._id);
+      --pit.warn(msg.&TOOLKIT._EVENT_NOT_ALLOWED, msg_args(p_fev_id, p_req.&TOOLKIT._fst_id), p_req.&TOOLKIT._id);
       g_result := c_ok;
     end if;
-    pit.leave;
+    --pit.leave;
     return g_result;
   end raise_event;
     
@@ -218,9 +219,9 @@ as
     return integer
   as
   begin
-    pit.enter('set_status', c_pkg);
+    --pit.enter('set_status', c_pkg);
     persist(p_req);
-    pit.leave;
+    --pit.leave;
     return &TOOLKIT._pkg.C_OK;
   exception
     when others then


### PR DESCRIPTION
I just 'cut out' everything which is referenced the PIT and move the  char_table type to this package.

Know FCT can install without PIT And every object compiled without error.